### PR TITLE
RFC: Filter by year

### DIFF
--- a/src/dashboard/dashboard.html
+++ b/src/dashboard/dashboard.html
@@ -1,3 +1,9 @@
+<!-- Filters -->
+<div id="filters">
+  Year
+  <select id="year"></select>
+</div>
+
 <!-- Charts -->
 <div id="charts" class="ns-section">
   <div id="moviesVsTvTime" class="ns-card-chart">

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -7,7 +7,7 @@
   "content_scripts": [
     {
       "matches": [
-        "https://www.netflix.com/settings/viewed?stats=true"
+        "https://www.netflix.com/settings/viewed?stats=true*"
       ],
       "js": [
         "vendor/js/lodash.min.js", 
@@ -24,6 +24,7 @@
         "utils/chart.js",
         "utils/viewing.js",
         "utils/format.js",
+        "utils/filters.js",
         "utils/debug.js",
         "dashboard/dashboard.js"],
       "css": [

--- a/src/utils/filters.js
+++ b/src/utils/filters.js
@@ -1,0 +1,58 @@
+function hydrateFilters(items) {
+  const parent = document.getElementById('filters');
+  const select = parent.firstElementChild;
+  const activeYears = getActiveYears(items);
+  const activeFilters = getActiveFilters();
+
+  debug(`active years ${activeYears}`);
+  const defaultOption = buildOption('-');
+  select.append(defaultOption);
+
+  activeYears.forEach(year => {
+    const isSelected = activeFilters.year === year;
+    const option = buildOption(year, isSelected);
+    select.append(option);
+  });
+
+  select.addEventListener('change', event => {
+    const year = event.target.value;
+    window.location = `https://www.netflix.com/settings/viewed?stats=true&year=${year}`;
+  });
+}
+
+function getActiveYears(items) {
+  const firstItem = items[0];
+  const lastItem = items[items.length - 1];
+  const newerYear = getYearFromDate(firstItem.date);
+  const olderYear = getYearFromDate(lastItem.date);
+  return _.range(olderYear, newerYear + 1);
+}
+
+function buildOption(value, selected) {
+  const $option = $(`<option ${selected ? 'selected' : ''} value=${value}>${value}</option>`);
+  return $option.get(0);
+}
+
+function getActiveFilters(items) {
+  const urlSearchParams = new URLSearchParams(window.location.search);
+  const year = parseInt(urlSearchParams.get('year'));
+  return { year };
+}
+
+function getYearFromDate(dateStr) {
+  const date = new Date(dateStr);
+  return date.getFullYear();
+}
+
+function getFilteredItems(items) {
+  const year = getActiveFilters().year;
+
+  if (!year) {
+    return items;
+  }
+
+  debug(`filtering by year ${year}`);
+  return items.filter(item => {
+    return year === getYearFromDate(item.date);
+  });
+}


### PR DESCRIPTION
Adds filtering functionality via query params. Currently only works for selecting usage by year.

Runs a filter in between saved/new data retrieval and dashboard building. Same mechanism could be used to build more complex filtering scenarios.

Built for personal use, but opening discussion to see if there's any interest in adding this to the extension (which is very nice by the way!).

![image](https://user-images.githubusercontent.com/5052387/147902673-490ae02c-c92e-420e-8bda-901c3aff3d5e.png)
 